### PR TITLE
Fix updating the uses

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -52,7 +52,7 @@ new Vue({
           {
             name: 'uses_left',
             align: 'right',
-            label: 'Uses left (Total)',
+            label: 'Uses left',
             field: 'uses_left'
           },
           {name: 'min', align: 'right', label: 'Min (sat)', field: 'min_fsat'},

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -44,9 +44,15 @@ new Vue({
             field: 'wait_time'
           },
           {
+            name: 'uses',
+            align: 'right',
+            label: 'Created',
+            field: 'uses'
+          },
+          {
             name: 'uses_left',
             align: 'right',
-            label: 'Uses left',
+            label: 'Uses left (Total)',
             field: 'uses_left'
           },
           {name: 'min', align: 'right', label: 'Min (sat)', field: 'min_fsat'},

--- a/views_api.py
+++ b/views_api.py
@@ -115,7 +115,16 @@ async def api_link_create_or_update(
             )
         
         data_dict = data.dict() 
-        if(link.uses < data.uses):
+        if link.uses > data.uses:
+            if data.uses - link.used <= 0:
+                raise HTTPException(
+                    detail="Cannot reduce uses below current used.", status_code=HTTPStatus.BAD_REQUEST
+                )
+            numbers = link.usescsv.split(",")
+            usescsv = ",".join(numbers[:data.uses - link.used])
+            data_dict["usescsv"] = usescsv
+
+        if link.uses < data.uses:
             numbers = link.usescsv.split(",")
             current_number = int(numbers[-1])
             while len(numbers) < (data.uses - link.used):

--- a/views_api.py
+++ b/views_api.py
@@ -113,7 +113,18 @@ async def api_link_create_or_update(
             raise HTTPException(
                 detail="Not your withdraw link.", status_code=HTTPStatus.FORBIDDEN
             )
-        link = await update_withdraw_link(link_id, **data.dict())
+        
+        data_dict = data.dict() 
+        if(link.uses < data.uses):
+            numbers = link.usescsv.split(",")
+            current_number = int(numbers[-1])
+            while len(numbers) < (data.uses - link.used):
+                current_number += 1
+                numbers.append(str(current_number))
+            usescsv = ",".join(numbers)
+            data_dict["usescsv"] = usescsv
+                        
+        link = await update_withdraw_link(link_id, **data_dict)
     else:
         link = await create_withdraw_link(wallet_id=wallet.wallet.id, data=data)
     assert link


### PR DESCRIPTION
Properly update the `usescsv` in DB and links CSV export, to handle increasing the number of uses.

### Test scenario
Previously when editing/updating the number of uses of an LNURLw the number of uses in the DB would get screwed and links would get buggy!

**Steps:**
1. Create a withdraw link (check CSV table)
2. Use it a couple of times
3. Edit the withdraw lnurl to increase the number of uses (re- check CSV table)

**Expected result:**
The links should have updated the number of uses, keeping the previous count. The CSV should have the correct amount of unique LNURL's
