### PR TITLE
Update crud.py

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -12,7 +12,7 @@ from .models import CreateWithdrawData, HashCheck, WithdrawLink
 async def create_withdraw_link(
     data: CreateWithdrawData, wallet_id: str
 ) -> WithdrawLink:
-    link_id = urlsafe_short_hash()[:6]
+    link_id = urlsafe_short_hash()[:22]
     available_links = ",".join([str(i) for i in range(data.uses)])
     await db.execute(
         """


### PR DESCRIPTION
In LNbits, each lnurlw is retrievable through a url as identified by its short hash (e.g. `https://legend.lnbits.com/withdraw/X5iYZN`).

With only six digits this url is probably far from "safe" and only allows about 38 billion possible combinations.
I propose to revert to the previous 22 digits to make it more difficult to brute-force all possible combinations and retrieve all lnurlws from the server.