### PR TITLE
Change min sat value and max. number of vouchers

### DIFF
--- a/templates/withdraw/index.html
+++ b/templates/withdraw/index.html
@@ -167,23 +167,23 @@
           dense
           v-model.number="formDialog.data.min_withdrawable"
           type="number"
-          min="10"
-          label="Min withdrawable (sat, at least 10) *"
+          min="1"
+          label="Min withdrawable (sat, at least 1) *"
         ></q-input>
         <q-input
           filled
           dense
           v-model.number="formDialog.data.max_withdrawable"
           type="number"
-          min="10"
-          label="Max withdrawable (sat, at least 10) *"
+          min="1"
+          label="Max withdrawable (sat, at least 1) *"
         ></q-input>
         <q-input
           filled
           dense
           v-model.number="formDialog.data.uses"
           type="number"
-          max="250"
+          max="1000"
           :default="1"
           label="Amount of uses *"
         ></q-input>
@@ -341,15 +341,15 @@
           dense
           v-model.number="simpleformDialog.data.max_withdrawable"
           type="number"
-          min="10"
-          label="Withdraw amount per voucher (sat, at least 10)"
+          min="1"
+          label="Withdraw amount per voucher (sat, at least 1)"
         ></q-input>
         <q-input
           filled
           dense
           v-model.number="simpleformDialog.data.uses"
           type="number"
-          max="250"
+          max="1000"
           :default="1"
           label="Number of vouchers"
         ></q-input>

--- a/views_api.py
+++ b/views_api.py
@@ -71,8 +71,8 @@ async def api_link_create_or_update(
     link_id: Optional[str] = None,
     wallet: WalletTypeInfo = Depends(require_admin_key),
 ):
-    if data.uses > 250:
-        raise HTTPException(detail="250 uses max.", status_code=HTTPStatus.BAD_REQUEST)
+    if data.uses > 1000:
+        raise HTTPException(detail="1000 uses max.", status_code=HTTPStatus.BAD_REQUEST)
 
     if data.min_withdrawable < 1:
         raise HTTPException(


### PR DESCRIPTION
### **Issue:** 
Min. sat value and max. number of vouchers.

**My two sats:**
Today  i made some changes to this extension on my own server. I asked myself for a long time "why is max amount of vouchers limited to 250 and why is min. amount 10 sats". It seems random to me. Since i got not a propper answer is played with my own lnbits and changed the values.

If there are no security thoughts behind that values i would argue that we now have the privilege to make small payments and withdrawls down to a piece of a cent. We should use that and change this extension. 

Set max numbers of vouchers to 1000 makes it easier to fullfile some larger tables of withdrawls. 1000 even better for the monk inside me. lol

**Summary:**
Changed min. value/withdrawl from 10 sat to 1 sat
Changed max. amount of vouchers from 250 to 1000