### PR TITLE
Add withdrawal_link_id to 'extra' database field for payments

### DIFF
--- a/lnurl.py
+++ b/lnurl.py
@@ -116,7 +116,7 @@ async def api_lnurl_callback(
             wallet_id=link.wallet,
             payment_request=pr,
             max_sat=link.max_withdrawable,
-            extra={"tag": "withdraw"},
+            extra={"tag": "withdraw", "withdrawal_link_id": link.id},
         )
         if link.webhook_url:
             await dispatch_webhook(link, payment_hash, pr)


### PR DESCRIPTION
Follow up for https://github.com/lnbits/withdraw/pull/23#issuecomment-1929396219.

We are using LnBits with this extension for lightning withdrawals in my company. In the current state we are unable to associate payments with lnurlw.