### PR TITLE
Fix withdraw increment

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -116,6 +116,7 @@ async def increment_withdraw_link(link: WithdrawLink) -> None:
         open_time=link.wait_time + int(datetime.now().timestamp()),
     )
 
+
 async def update_withdraw_link(link_id: str, **kwargs) -> Optional[WithdrawLink]:
     if "is_unique" in kwargs:
         kwargs["is_unique"] = int(kwargs["is_unique"])
@@ -128,6 +129,7 @@ async def update_withdraw_link(link_id: str, **kwargs) -> Optional[WithdrawLink]
         "SELECT * FROM withdraw.withdraw_link WHERE id = ?", (link_id,)
     )
     return WithdrawLink(**row) if row else None
+
 
 async def delete_withdraw_link(link_id: str) -> None:
     await db.execute("DELETE FROM withdraw.withdraw_link WHERE id = ?", (link_id,))

--- a/crud.py
+++ b/crud.py
@@ -116,13 +116,6 @@ async def increment_withdraw_link(link: WithdrawLink) -> None:
         open_time=link.wait_time + int(datetime.now().timestamp()),
     )
 
-async def unincrement_withdraw_link(link: WithdrawLink) -> None:
-    await update_withdraw_link(
-        link.id,
-        used=link.used - 1,
-        open_time=link.wait_time + int(datetime.now().timestamp()),
-    )
-
 async def update_withdraw_link(link_id: str, **kwargs) -> Optional[WithdrawLink]:
     if "is_unique" in kwargs:
         kwargs["is_unique"] = int(kwargs["is_unique"])

--- a/crud.py
+++ b/crud.py
@@ -116,6 +116,12 @@ async def increment_withdraw_link(link: WithdrawLink) -> None:
         open_time=link.wait_time + int(datetime.now().timestamp()),
     )
 
+async def unincrement_withdraw_link(link: WithdrawLink) -> None:
+    await update_withdraw_link(
+        link.id,
+        used=link.used - 1,
+        open_time=link.wait_time + int(datetime.now().timestamp()),
+    )
 
 async def update_withdraw_link(link_id: str, **kwargs) -> Optional[WithdrawLink]:
     if "is_unique" in kwargs:

--- a/crud.py
+++ b/crud.py
@@ -129,7 +129,6 @@ async def update_withdraw_link(link_id: str, **kwargs) -> Optional[WithdrawLink]
     )
     return WithdrawLink(**row) if row else None
 
-
 async def delete_withdraw_link(link_id: str) -> None:
     await db.execute("DELETE FROM withdraw.withdraw_link WHERE id = ?", (link_id,))
 

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,49 @@
+from threading import Lock
+from typing import Dict
+
+
+class CounterLock:
+    def __init__(self):
+        self.counter = 0
+        self.lock = Lock()
+
+    def acquire(self) -> bool:
+        self.counter += 1
+        return self.lock.acquire()
+
+    def release(self) -> None:
+        self.counter -= 1
+        return self.lock.release()
+
+    @property
+    def no_more_waiters(self) -> bool:
+        return self.counter == 0
+
+
+class NamedLock:
+    _lock = Lock()
+    _locks: Dict[str, CounterLock] = {}
+
+    def acquire(self, name: str) -> bool:
+        self._lock.acquire()
+
+        if name not in self._locks:
+            self._locks[name] = CounterLock()
+
+        self._lock.release()
+
+        return self._locks[name].acquire()
+
+
+
+    def release(self, name: str):
+        self._lock.acquire()
+
+        if name not in self._locks:
+            return self._lock.release()
+
+        self._locks[name].release()
+        if self._locks[name].no_more_waiters:
+            del self._locks[name]
+
+        return self._lock.release()

--- a/lnurl.py
+++ b/lnurl.py
@@ -16,11 +16,12 @@ from . import withdraw_ext
 from .crud import (
     get_withdraw_link_by_hash,
     increment_withdraw_link,
-    unincrement_withdraw_link,
     remove_unique_withdraw_link,
 )
 from .models import WithdrawLink
+from .helpers import NamedLock
 
+withdraw_lock = NamedLock()
 
 @withdraw_ext.get(
     "/api/v1/lnurl/{unique_hash}",
@@ -82,6 +83,31 @@ async def api_lnurl_callback(
     pr: str = Query(...),
     id_unique_hash=None,
 ):
+    link = await _check_withdraw_link_safe(unique_hash, k1, id_unique_hash)
+
+    try:
+        payment_hash = await pay_invoice(
+            wallet_id=link.wallet,
+            payment_request=pr,
+            max_sat=link.max_withdrawable,
+            extra={"tag": "withdraw", "withdrawal_link_id": link.id},
+        )
+        if link.webhook_url:
+            await dispatch_webhook(link, payment_hash, pr)
+        return {"status": "OK"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail=f"withdraw not working. {str(e)}"
+        )
+
+async def _check_withdraw_link_safe(unique_hash, k1, id_unique_hash) -> WithdrawLink:
+    try:
+        withdraw_lock.acquire(unique_hash)
+        return await _check_withdraw_link(unique_hash, k1, id_unique_hash)
+    finally:
+        withdraw_lock.release(unique_hash)
+
+async def _check_withdraw_link(unique_hash, k1, id_unique_hash) -> WithdrawLink:
     link = await get_withdraw_link_by_hash(unique_hash)
     now = int(datetime.now().timestamp())
     if not link:
@@ -93,9 +119,11 @@ async def api_lnurl_callback(
         raise HTTPException(
             status_code=HTTPStatus.METHOD_NOT_ALLOWED, detail="withdraw is spent."
         )
-    await increment_withdraw_link(link)
+
     if link.k1 != k1:
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="k1 is wrong.")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="k1 is wrong."
+        )
 
     if now < link.open_time:
         raise HTTPException(
@@ -110,22 +138,13 @@ async def api_lnurl_callback(
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND, detail="withdraw not found."
             )
+    await increment_withdraw_link(link)
 
-    try:
-        payment_hash = await pay_invoice(
-            wallet_id=link.wallet,
-            payment_request=pr,
-            max_sat=link.max_withdrawable,
-            extra={"tag": "withdraw", "withdrawal_link_id": link.id},
-        )
-        if link.webhook_url:
-            await dispatch_webhook(link, payment_hash, pr)
-        return {"status": "OK"}
-    except Exception as e:
-        await unincrement_withdraw_link(link)
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST, detail=f"withdraw not working. {str(e)}"
-        )
+    return link
+
+
+
+
 
 
 def check_unique_link(link: WithdrawLink, unique_hash: str) -> bool:


### PR DESCRIPTION
### Summary
Make sure that increment is called sync for the same withdraw link.

The checking logic has been extracted to `_check_withdraw_link`.
The `_check_withdraw_link_safe` function makes sure that for one particular withdraw link the check&increment is not atomic.


The `NamedLock` class holds a dictionary of `CounterLocks`. When there is now waiter for a lock then the entry is removed from the dictionary.

**Note**:
 - do not make an HTTP call to the LNbits own API while inside `Lock.acquire()`. It can lead to a deadlock.
