### PR TITLE
Fix: Add check if no uses left and uses needs to be incremented

### DIFF
--- a/views_api.py
+++ b/views_api.py
@@ -126,7 +126,13 @@ async def api_link_create_or_update(
 
         if link.uses < data.uses:
             numbers = link.usescsv.split(",")
-            current_number = int(numbers[-1])
+            
+            if numbers[-1] == "":
+                current_number = int(link.uses)
+                numbers[-1] = str(link.uses)
+            else:
+                current_number = int(numbers[-1])
+                
             while len(numbers) < (data.uses - link.used):
                 current_number += 1
                 numbers.append(str(current_number))


### PR DESCRIPTION
Fixes: https://github.com/lnbits/withdraw/issues/38

We need to check if `usescsv` is empty. If all `uses` were consumed, `usescsv` is just an empty string. In this case, we need to handle it differently. We need to set `current_numbers` to the last value of uses and also update `usescsv` accordingly.

If we don't handle this behavior, it won't be possible to update an already used withdraw link to reuse it again.