### PR TITLE
Add paginated fetching to withdraw link table

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -86,15 +86,26 @@ async def get_withdraw_link_by_hash(unique_hash: str, num=0) -> Optional[Withdra
     return WithdrawLink.parse_obj(link)
 
 
-async def get_withdraw_links(wallet_ids: Union[str, List[str]]) -> List[WithdrawLink]:
-    if isinstance(wallet_ids, str):
-        wallet_ids = [wallet_ids]
-
-    q = ",".join(["?"] * len(wallet_ids))
+async def get_withdraw_links(wallet_ids: List[str], limit: int, offset: int) -> (List[WithdrawLink], int):
     rows = await db.fetchall(
-        f"SELECT * FROM withdraw.withdraw_link WHERE wallet IN ({q}) ORDER BY open_time DESC", (*wallet_ids,)
+        """
+        SELECT * FROM withdraw.withdraw_link
+        WHERE wallet IN ({})
+        ORDER BY open_time DESC
+        LIMIT ? OFFSET ?
+        """.format(','.join('?' * len(wallet_ids))),
+        (*wallet_ids, limit, offset)
     )
-    return [WithdrawLink(**row) for row in rows]
+    
+    total = await db.fetchone(
+        """
+        SELECT COUNT(*) as total FROM withdraw.withdraw_link
+        WHERE wallet IN ({})
+        """.format(','.join('?' * len(wallet_ids))),
+        (*wallet_ids,)
+    )
+    
+    return [WithdrawLink(**row) for row in rows], total['total']
 
 
 async def remove_unique_withdraw_link(link: WithdrawLink, unique_hash: str) -> None:

--- a/templates/withdraw/index.html
+++ b/templates/withdraw/index.html
@@ -32,6 +32,7 @@
           row-key="id"
           :columns="withdrawLinksTable.columns"
           :pagination.sync="withdrawLinksTable.pagination"
+          @request="getWithdrawLinks"
         >
           {% raw %}
           <template v-slot:header="props">


### PR DESCRIPTION
We had a severe bug in the Withdraw Extension that prevented us from using the UI. In our app, we handle many different users, and each user will eventually receive an LNURLw link. With thousands of links in the database, it was not very efficient to load all the links simultaneously. Many times we received a "502 Bad Gateway" error because the response took too long. This caused a significant chain reaction because our LNBits instance was completely down afterward, requiring us to reset with a backup to get things running again.

By implementing a paginated loading of the table, this issue would not occur anymore, and the Withdraw plugin would load much faster initially as well.