### PR TITLE
Added paginated fetching to withdraw link table

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -59,7 +59,9 @@ new Vue({
           {name: 'max', align: 'right', label: 'Max (sat)', field: 'max_fsat'}
         ],
         pagination: {
-          rowsPerPage: 10
+          page: 1,
+          rowsPerPage: 10,
+          rowsNumber: 0
         }
       },
       nfcTagWriting: false,
@@ -97,19 +99,30 @@ new Vue({
     }
   },
   methods: {
-    getWithdrawLinks: function () {
+    getWithdrawLinks: function (props) {
+      if (props) {
+        this.withdrawLinksTable.pagination = props.pagination
+      }
+
+      let pagination = this.withdrawLinksTable.pagination
+      const query = {
+        limit: pagination.rowsPerPage,
+        offset: (pagination.page - 1) * pagination.rowsPerPage
+      }
+
       var self = this
 
       LNbits.api
         .request(
           'GET',
-          '/withdraw/api/v1/links?all_wallets=true',
+          `/withdraw/api/v1/links?all_wallets=true&limit=${query.limit}&offset=${query.offset}`,
           this.g.user.wallets[0].inkey
         )
         .then(function (response) {
-          self.withdrawLinks = response.data.map(function (obj) {
+          self.withdrawLinks = response.data.data.map(function (obj) {
             return mapWithdrawLink(obj)
           })
+          self.withdrawLinksTable.pagination.rowsNumber = response.data.total
         })
         .catch(function (error) {
           clearInterval(self.checker)
@@ -309,11 +322,8 @@ new Vue({
   },
   created: function () {
     if (this.g.user.wallets.length) {
-      var getWithdrawLinks = this.getWithdrawLinks
-      getWithdrawLinks()
-      this.checker = setInterval(function () {
-        getWithdrawLinks()
-      }, 300000)
+      this.getWithdrawLinks()
+      this.checker = setInterval(this.getWithdrawLinks, 300000)
     }
   }
 })

--- a/templates/withdraw/index.html
+++ b/templates/withdraw/index.html
@@ -32,6 +32,7 @@
           row-key="id"
           :columns="withdrawLinksTable.columns"
           :pagination.sync="withdrawLinksTable.pagination"
+          @request="getWithdrawLinks"
         >
           {% raw %}
           <template v-slot:header="props">

--- a/views_api.py
+++ b/views_api.py
@@ -25,6 +25,8 @@ async def api_links(
     req: Request,
     wallet: WalletTypeInfo = Depends(get_key_type),
     all_wallets: bool = Query(False),
+    offset: int = Query(0),
+    limit: int = Query(0),
 ):
     wallet_ids = [wallet.wallet.id]
 
@@ -33,10 +35,11 @@ async def api_links(
         wallet_ids = user.wallet_ids if user else []
 
     try:
-        return [
-            {**link.dict(), **{"lnurl": link.lnurl(req)}}
-            for link in await get_withdraw_links(wallet_ids)
-        ]
+        links, total = await get_withdraw_links(wallet_ids, limit, offset)
+        return {
+            "data": [{**link.dict(), **{"lnurl": link.lnurl(req)}} for link in links],
+            "total": total,
+        }
 
     except LnurlInvalidUrl as exc:
         raise HTTPException(


### PR DESCRIPTION
We had a severe bug in the Withdraw Extension that prevented us from using the UI. In our app, we handle many different users, and each user will eventually receive an LNURLw link. With thousands of links in the database, it was not very efficient to load all the links simultaneously. Many times we received a "502 Bad Gateway" error because the response took too long. This caused a significant chain reaction because our LNBits instance was completely down afterward, requiring us to reset with a backup to get things running again.

By implementing a paginated loading of the table, this issue would not occur anymore, and the Withdraw plugin would load much faster initially as well.